### PR TITLE
Bug fixing in request method in resource-json-feed.ts

### DIFF
--- a/src/resource-common/resource-sources/resource-json-feed.ts
+++ b/src/resource-common/resource-sources/resource-json-feed.ts
@@ -28,7 +28,7 @@ registerResourceSourceDef({
     let meta: JsonFeedMeta = arg.resourceSource.meta
     let requestParams = buildRequestParams(meta, arg.range, arg.calendar)
 
-    requestJson('GET', meta.url, requestParams, function(rawResources, xhr) {
+    requestJson(meta.method, meta.url, requestParams, function(rawResources, xhr) {
       successCallback({ rawResources, xhr })
     }, function(message, xhr) {
       failureCallback({ message, xhr })


### PR DESCRIPTION
Bug: When loading resources, GET method is always used, even if the POST method is explicitly specified.

https://codepen.io/igor0u/pen/PgGrEg
open devtools->network and look for request method of resource url.